### PR TITLE
Add Philly MacAdmins YouTube channel to index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,3 +33,10 @@ _Playlists:_
 - [2023–present by conference day](https://www.youtube.com/@MacSysAdminConference/playlists)
 
 _Notes:_ Additional content (e.g., slide decks) available on the [MacSysAdmin website](https://documentation.macsysadmin.se/index.html).
+
+## Greater Philadelphia (Philly) MacAdmins
+
+_Account 2015-present:_ [@phillymacadmins on YouTube](https://www.youtube.com/@phillymacadmins)
+
+_Notes:_ [Greater Philadelphia MacAdmins Website](https://phillymacadmins.com/)
+


### PR DESCRIPTION
Adding Philly MacAdmins videos

### :clipboard: Summary

Adding Philly MacAdmins as a video source. 

### :test_tube: Testing

Verified that links work. 

### :information_source: Additional context

- N/A
